### PR TITLE
Update Deviantart.xml

### DIFF
--- a/src/chrome/content/rules/Deviantart.xml
+++ b/src/chrome/content/rules/Deviantart.xml
@@ -47,7 +47,7 @@
 			Mustn't rewrite from https here, as doing so
 		would conflict with the first rule.
 								-->
-	<rule from="^http://([^/:@\.]+\.)?deviantart\.(?:com|net)/"
-		to="https://$1deviantart.com/" />
+	<rule from="^http://([^/:@\.]+\.)?deviantart\.(com|net)/"
+		to="https://$1deviantart.$2/" />
 
 </ruleset>


### PR DESCRIPTION
2nd rule would previously fail for deviantart.net because it changed the TLD to into deviantart.com. Added 2nd capture group like the first rule.