### PR TITLE
Update Deviantart.xml

### DIFF
--- a/src/chrome/content/rules/Deviantart.xml
+++ b/src/chrome/content/rules/Deviantart.xml
@@ -7,49 +7,28 @@
 		- Sta.sh.xml
 
 
-	ToDo: Find edgecast URL for /(fc|th)\d+.
-
-
 	Mixed content:
 
 		- Images on *.....com from e.deviantart.net *
 
 	* Secured by us
 
+	chat.deviantart.com currently times out over HTTPS. The rule needs to be disabled
+	before visiting this page in order to log in with insecure cookies.
+
 -->
-<ruleset name="DeviantArt (pending)" default_off="site operator says not ready yet">
+<ruleset name="DeviantArt (pending)" default_off="works everywhere except for chat.deviantart.com">
 
 	<target host="deviantart.com" />
 	<target host="*.deviantart.com" />
 	<target host="deviantart.net" />
 	<target host="*.deviantart.net" />
 
-
-	<!--	Not secured by server:
-					-->
-	<!--securecookie host="^\.deviantart\.com$" name="^userinfo$" /-->
-
 	<securecookie host="^\.deviantart\.com$" name=".*" />
 
+	<rule from="^http://(?!chat\.)([^/:@\.]+\.)?deviantart\.(com|net)/"
+		to="https://$1deviantart.$2/"/>
 
-	<!--	Redirects from com to net, but does so successfully by itself.
-										-->
-	<rule from="^http://([aei]|fc\d\d|img\d\d|orig\d\d|pre\d\d|s[ht]|th?\d\d)\.deviantart\.(com|net)/"
-		to="https://$1.deviantart.$2/" />
-
-	<!--	This handles everything that isn't in the first rule.
-		Namely, usernames, backend, fc, th, and (www.).
-			These domains present a cert that is only
-		valid for .com.
-			Note that .net isn't used on DA, but.net does
-		redirect to .com, and we shouldn't break what would
-		otherwise work.
-			Mustn't rewrite from https here, as doing so
-		would conflict with the first rule.
-								-->
-	<rule from="^http://([^/:@.]+\.)?deviantart\.(?:com|net)/"
-		to="https://$1deviantart.com/" />
-
-		<test url="http://27d.deviantart.com/" />
+	<test url="http://27d.deviantart.com/" />
 
 </ruleset>


### PR DESCRIPTION
New rule that applies to everything on deviantart.com and .net except for chat.deviantart.com (currently times out over HTTPS)